### PR TITLE
Fix for dynamic locale selection bug.

### DIFF
--- a/src/info/guardianproject/browser/OrwebApp.java
+++ b/src/info/guardianproject/browser/OrwebApp.java
@@ -40,7 +40,7 @@ public class OrwebApp extends Application
     	
     	boolean updated = false;
     	
-    	if (!config.locale.getLanguage().equals(lang))
+    	if (!config.locale.getLanguage().equalsIgnoreCase(lang))
     	{
     		config.locale = locale;
     		getResources().updateConfiguration(config, getResources().getDisplayMetrics());


### PR DESCRIPTION
Locale.getLanguage() always returns a lowercase string, which
would falsely fail comparison with locales you have defined
with uppercase components like pt_BR and nb_NO, causing the
Browser activity to restart itself on every onResume() event
when running in those locales.  I believe that would be an
infinite loop.