### PR TITLE
Fix typo in 'Deutsch'

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -31,7 +31,7 @@
 		<item>پارسی</item>
 		<item>中文(简体)</item>
 		<item>Dansk</item>
-		<item>Deutsche</item>
+		<item>Deutsch</item>
 		<item>Español</item>
 		<item>Esperanto</item>
 		<item>Français</item>


### PR DESCRIPTION
It must be 'Deutsch' not 'Deutsche'.